### PR TITLE
make Contao 4 installation possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "contao/core": "~3.2 || ~4.1",
+        "contao/core-bundle": "~3.2 || ~4.1",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },
     "autoload": {


### PR DESCRIPTION
The current `composer.json` contains an error that makes it impossible to let it install into Contao 4. The requirement must be `contao/core-bundle`, not `contao/core`.

_Note:_ this still makes it possible to install it into Contao 3 as well (due to the special handling of the contao/core-bundle within the composer-plugin).